### PR TITLE
fix(docs): use object syntax for logo

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -7,7 +7,7 @@ export default withMermaid(
     description: "TurfTrack Documentation",
     base: "/TurfTrack/",
     themeConfig: {
-      logo: "/logo.png", // You will need to add a logo to docs/public/logo.png
+      logo: { src: "/logo.png", alt: "TurfTrack Logo" },
       nav: [
         { text: "Home", link: "/" },
         { text: "GitHub", link: "https://github.com/RunOnYourOwn/TurfTrack" },


### PR DESCRIPTION
Updates the VitePress theme config to reference the logo using the object syntax ({ src, alt }). This is a more robust method that may help the build process resolve the asset path correctly.