### PR TITLE
chore(ci): add debug step to docs deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
         working-directory: docs
         run: npm run docs:build
 
+      - name: List build output for debugging
+        run: ls -R docs/.vitepress/dist
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
Adds a step to the deploy-docs job to list the contents of the build output directory. This will help diagnose why static assets like the logo are not appearing on the live site.