### PR TITLE
fix(docs): explicitly set publicDir in VitePress config

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -6,6 +6,7 @@ export default withMermaid(
     title: "TurfTrack",
     description: "TurfTrack Documentation",
     base: "/TurfTrack/",
+    publicDir: ".vitepress/public",
     themeConfig: {
       logo: { src: "/logo.png", alt: "TurfTrack Logo" },
       nav: [


### PR DESCRIPTION
Adds the 'publicDir' setting to the VitePress configuration to explicitly point to the static asset directory. This should resolve the issue where the logo was not being included in the final build output.