### PR TITLE
fix: use softprops/action-gh-release instead of gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,13 +352,14 @@ jobs:
           } > /tmp/release-notes.md
 
       - name: Create Draft Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Release ${{ github.ref_name }}"
+          body_path: /tmp/release-notes.md
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ github.ref_name }} \
-            --draft \
-            --title "Release ${{ github.ref_name }}" \
-            --notes-file /tmp/release-notes.md
 
       - name: Cleanup workspace
         if: always()


### PR DESCRIPTION
## Summary
- Self-hosted runner doesn't have `gh` CLI installed, causing Create Draft Release to fail with exit code 127
- Replace `gh release create` with `softprops/action-gh-release@v2` action

## Test plan
- [ ] Merge, retag v0.0.23, verify draft release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)